### PR TITLE
Raise minimum SDK to 9 (fixes #3)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.3"
     defaultConfig {
         applicationId "org.seamapdroid"
-        minSdkVersion 7
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 25
         versionName "1.4.2"


### PR DESCRIPTION
Hello,

This fixes the build issue but removes compatibility with Android 2.1 and 2.2 (but nobody uses these version anymore).